### PR TITLE
Add github-actions to Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,3 +25,15 @@ updates:
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-patch", "version-update:semver-minor", "version-update:semver-major"]
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+          - "version-update:semver-minor"
+          - "version-update:semver-major"


### PR DESCRIPTION
## Summary
- Hygiene for actively maintained fork: security-only Dependabot / settings so deps stay current
- Listed in housekeeping `config.toml` `active_forks`

## Test plan
- [ ] Dependabot config accepted after merge
- [ ] Security settings look right in repo Settings → Code security


Made with [Cursor](https://cursor.com)