### PR TITLE
chore(ci): bump Actions to Node 24-capable majors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       charts: ${{ steps.filter.outputs.charts }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - uses: dorny/paths-filter@v3
         id: filter
@@ -37,7 +37,7 @@ jobs:
     if: needs.changes.outputs.go == 'true'
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3


### PR DESCRIPTION
## Summary
- Bump first-party GitHub Actions still on the Node 20 *action runtime* to Node-24-capable majors (`checkout`/`setup-node`/`cache`/`upload-artifact`/`download-artifact` → v5+, `setup-python` → v6+).
- Does **not** change job `node-version` / language toolchains.

## Test plan
- [ ] CI green on this PR
- [ ] No \"Node.js 20 is deprecated\" annotation on workflow runs


Made with [Cursor](https://cursor.com)